### PR TITLE
Add repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "keywords": [
     "ember-addon"
   ],
-  "repository": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ember-polyfills/ember-named-blocks-polyfill.git",
+  },
   "license": "MIT",
   "author": "",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ember-polyfills/ember-named-blocks-polyfill.git",
+    "url": "https://github.com/ember-polyfills/ember-named-blocks-polyfill.git"
   },
   "license": "MIT",
   "author": "",


### PR DESCRIPTION
This fills out the `"repository"` property in `package.json`.

Google kept leading me to [the npmjs.com page for this addon](https://www.npmjs.com/package/ember-named-blocks-polyfill), which didn't have a link to the repo here because this config was missing.