### PR TITLE
Disable ember version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ ember-named-blocks-polyfill
 ==============================================================================
 
 This addon provides a polyfill for the [Yieldable Named Blocks][RFC] feature.
-On Ember.js versions with native support for the feature, this addon is inert.
+When the feature lands in Ember.js, this addon will be updated to be inert on
+versions with native support.
 
 
 Compatibility

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const VersionChecker = require('ember-cli-version-checker');
 
-const MINIMUM_NAMED_BLOCKS_VERSION = '3.20.0-beta.0';
+const MINIMUM_NAMED_BLOCKS_VERSION = '99.99.99';
 
 module.exports = {
   name: require('./package').name,


### PR DESCRIPTION
We are not able to resolve the differences (mostly due to time) before the release goes out and had to disable the feature. Will add back the check when the feature becomes available again.