### PR TITLE
Move `ember-cli-htmlbars` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.19.0",
-    "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-version-checker": "^5.1.1"
   },
   "devDependencies": {
@@ -42,6 +41,7 @@
     "ember-auto-import": "^1.5.3",
     "ember-cli": "~3.18.0",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",


### PR DESCRIPTION
This addon has no templates of its own, and does not use inline compilation in its JS.