### PR TITLE
fix: use version checker correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
 
   usePolyfill() {
     if (this._usePolyfill === undefined) {
-      let version = new VersionChecker(this).for(`ember-source`);
+      let version = new VersionChecker(this.project).for(`ember-source`);
       this._usePolyfill = version.lt(MINIMUM_NAMED_BLOCKS_VERSION);
     }
 


### PR DESCRIPTION
`VersionChecker(this)` is an invalid usage according to https://github.com/ember-cli/ember-cli-version-checker#should-i-use-project-or-parent which specifically causes issues when an addon is used in a yarn workspace that has mixed versions of ember-source

Based on this PR for the ember-in-element-polyfill
https://github.com/ember-polyfills/ember-in-element-polyfill/pull/206

I'll admit I haven't hit this issue  _for this project_ yet, (all my apps/addons are on Ember 3.24) but I am pre-empting the issue before my workspace blows up :) (I've had this exact problem on other ember polyfill projects, like the one I linked above)