### PR TITLE
Limit testing to ember 3.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,11 @@ jobs:
           - default
           - default-with-lockfile
           - default-with-jquery
-          - release
-          - beta
-          - canary
           - classic
           - lts-3.12
           - lts-3.16
           - lts-3.20
+          - lts-3.28
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const getChannelURL = require('ember-source-channel-url');
-
 module.exports = async function() {
   return {
     useYarn: true,
@@ -31,26 +29,10 @@ module.exports = async function() {
         }
       },
       {
-        name: 'ember-release',
+        name: 'ember-lts-3.28',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('release')
-          }
-        }
-      },
-      {
-        name: 'ember-beta',
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('beta')
-          }
-        }
-      },
-      {
-        name: 'ember-canary',
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('canary')
+            'ember-source': '~3.28.0'
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.0",
     "ember-source": "~3.18.0",
-    "ember-source-channel-url": "^2.0.1",
     "ember-template-lint": "^2.6.0",
     "ember-truth-helpers": "^2.1.0",
     "ember-try": "^1.4.0",


### PR DESCRIPTION
This polyfill is inert on ember 3.25+, so rather than do a big upgrade to get it testing under ember 4 I'm just capping the CI matrix at the final 3.x LTS.